### PR TITLE
Fix and upgrade pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.58.0
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.70.1
   hooks:
   - id: terraform_fmt
   - id: terraform_validate
   - id: terraform_docs
-    args: ["--args=--sort-by-required"]
+    args: ["--args=--sort-by required"]


### PR DESCRIPTION
### Background

- Change protocol for pre-commit modules to `https`
- Update `pre-commit-terraform` versions to `v1.70.1`